### PR TITLE
feat: improve dashboard with server actions

### DIFF
--- a/src/adapter/http-client.ts
+++ b/src/adapter/http-client.ts
@@ -17,7 +17,7 @@ class HttpClient {
         }
     };
 
-    async post<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    async post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
         try {
             return await this.instance.post<T>(url, data, config);
 
@@ -27,7 +27,7 @@ class HttpClient {
         }
     };
 
-    async patch<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    async patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
         try {
             return await this.instance.patch<T>(url, data, config);
         }
@@ -55,4 +55,5 @@ class HttpClient {
 
 }
 
-export default new HttpClient();
+const httpClient = new HttpClient()
+export default httpClient

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,12 @@
+'use server'
+
+import { getDataService } from '@/services/getData.service'
+import { TemperatureData } from '@/interfaces/dashboard.interface'
+
+export async function fetchTemperatureData(results: number): Promise<TemperatureData> {
+  const response = await getDataService(results)
+  if (response.status !== 200) {
+    throw new Error('Error al obtener los datos')
+  }
+  return response.data
+}

--- a/src/components/area-chart-temperature.tsx
+++ b/src/components/area-chart-temperature.tsx
@@ -1,15 +1,5 @@
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  ResponsiveContainer,
-  AreaChart,
-  Area,
-  ReferenceLine,
-} from "recharts"
+import { XAxis, YAxis, CartesianGrid, ResponsiveContainer, AreaChart, Area, ReferenceLine } from "recharts"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card"
 import { ChartDataPoint } from "@/interfaces/dashboard.interface"
 export const AreaChartTemperature = ({ chartData, yDomain, avgTemp }: { chartData: ChartDataPoint[], yDomain: [number, number], avgTemp: number }) => {
@@ -31,6 +21,12 @@ export const AreaChartTemperature = ({ chartData, yDomain, avgTemp }: { chartDat
             >
               <ResponsiveContainer width="100%" height="100%">
                 <AreaChart data={chartData}>
+                  <defs>
+                    <linearGradient id="temperatureArea" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="hsl(var(--chart-2))" stopOpacity={0.8} />
+                      <stop offset="100%" stopColor="hsl(var(--chart-2))" stopOpacity={0.1} />
+                    </linearGradient>
+                  </defs>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="time" fontSize={12} tickLine={false} axisLine={false} />
                   <YAxis
@@ -56,8 +52,7 @@ export const AreaChartTemperature = ({ chartData, yDomain, avgTemp }: { chartDat
                     type="monotone"
                     dataKey="temperature"
                     stroke="hsl(var(--chart-2))"
-                    fill="hsl(var(--chart-2))"
-                    fillOpacity={0.4}
+                    fill="url(#temperatureArea)"
                     strokeWidth={2}
                   />
                 </AreaChart>

--- a/src/components/line-chart-temperature.tsx
+++ b/src/components/line-chart-temperature.tsx
@@ -32,6 +32,12 @@ export const LineChartTemperature = ({ chartData, yDomain, avgTemp }: {chartData
             >
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={chartData}>
+                  <defs>
+                    <linearGradient id="temperatureLine" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="hsl(var(--chart-1))" stopOpacity={1} />
+                      <stop offset="100%" stopColor="hsl(var(--chart-1))" stopOpacity={0.2} />
+                    </linearGradient>
+                  </defs>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="time" fontSize={12} tickLine={false} axisLine={false} />
                   <YAxis
@@ -56,10 +62,11 @@ export const LineChartTemperature = ({ chartData, yDomain, avgTemp }: {chartData
                   <Line
                     type="monotone"
                     dataKey="temperature"
-                    stroke="hsl(var(--chart-1))"
+                    stroke="url(#temperatureLine)"
                     strokeWidth={3}
-                    dot={{ r: 5, strokeWidth: 2, fill: "hsl(var(--chart-1))" }}
-                    activeDot={{ r: 7, stroke: "hsl(var(--chart-1))", strokeWidth: 2 }}
+                    dot={{ r: 4, strokeWidth: 2, fill: "hsl(var(--chart-1))" }}
+                    activeDot={{ r: 6, stroke: "hsl(var(--chart-1))", strokeWidth: 2 }}
+                    strokeLinecap="round"
                   />
                 </LineChart>
               </ResponsiveContainer>

--- a/src/components/temperature-table.tsx
+++ b/src/components/temperature-table.tsx
@@ -1,0 +1,41 @@
+import { Badge } from "@/components/ui/badge"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { ChartDataPoint } from "@/interfaces/dashboard.interface"
+import { Thermometer } from "lucide-react"
+
+export function TemperatureTable({ data }: { data: ChartDataPoint[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Hora</TableHead>
+          <TableHead className="hidden sm:table-cell">Fecha Completa</TableHead>
+          <TableHead className="text-right">Temperatura</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data
+          .slice()
+          .reverse()
+          .map((point, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Badge variant="outline">{point.time}</Badge>
+              </TableCell>
+              <TableCell className="hidden sm:table-cell text-muted-foreground">
+                {point.fullTime}
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex items-center justify-end space-x-2">
+                  <Thermometer className="h-4 w-4 text-muted-foreground" />
+                  <span className="font-medium">
+                    {point.temperature.toFixed(2)}°C
+                  </span>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
+  <tfoot ref={ref} className={cn("bg-muted/50 font-medium", className)} {...props} />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", className)} {...props} />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <th ref={ref} className={cn("h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0", className)} {...props} />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)} {...props} />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/services/getData.service.ts
+++ b/src/services/getData.service.ts
@@ -1,10 +1,9 @@
 import httpClient from "@/adapter/http-client"
-import { TemperatureData } from "@/interfaces/dashboard.interface";
+import { TemperatureData } from "@/interfaces/dashboard.interface"
 
-
-export const getDataService = async () => {
-    const response  = await httpClient.get<TemperatureData>('?results=50');
-    return response;
-} 
+export const getDataService = async (results: number) => {
+  const response = await httpClient.get<TemperatureData>(`?results=${results}`)
+  return response
+}
 
 


### PR DESCRIPTION
## Summary
- fetch temperature data via server action with dynamic results
- add responsive table and input using shadcn components
- polish chart visuals with gradients

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4f7b03cc832a97ca6d3cef5698af